### PR TITLE
Optimized buttons for Firefox

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,9 +14,10 @@ const IndexPage = () =>
     <hr />
     <Grid className="imageSection" centered doubling stackable container columns={2}>
         <Grid.Column textAlign="center">
-          <Button className="resumeButton" basic color="blue"><Link to="/blog">B L O G</Link></Button>
           <Image className="image" className="profileImage" src="https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAoLAAAAJDlkYzRmYjVjLTJhNDgtNDEyMy04YzZlLTU0ZmZmZTQ4ODkxNg.jpg" />
-          <Button className="resumeButton" basic color='blue'><a href="https://drive.google.com/file/d/0B90tJM4IBtgNdGNBYU5CQzBtbDA/view?usp=sharing" target="_blank">R É S U M É</a></Button>
+          <Button className="resumeButton" basic color='blue' href="https://drive.google.com/file/d/0B90tJM4IBtgNdGNBYU5CQzBtbDA/view?usp=sharing" target="_blank">R É S U M É</Button> 
+          <br />
+          <Button className="resumeButton" basic color="green" href="/blog">B L O G</Button>
           <br />
           
         </Grid.Column>


### PR DESCRIPTION
> Buttons with link/anchor tags inside them were not functioning in Firefox
- Solved by placing and href attribute inside of the button tag itself.